### PR TITLE
解决正常互联网流量没有被转发的问题

### DIFF
--- a/start-web.sh
+++ b/start-web.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 basepath=$(cd `dirname $0`; pwd)
 cd $basepath
-mkdir node_modules
+mkdir -p node_modules
 cp -R ./douyu/* node_modules
 iptables -t nat -F
 #ip route add local default dev lo table 100
@@ -15,5 +15,7 @@ iptables -t nat -A PREROUTING -p tcp -s 192.168.200.0/24 --dport 1935 -j DNAT --
 iptables -t nat -A PREROUTING -p tcp -s 192.168.200.0/24 --dport 6667 -j DNAT --to-destination  192.168.200.1:6667
 #iptables -t nat -A PREROUTING --ipv4 -s 192.168.200.0/24 -p tcp -j DNAT --to-destination 192.168.200.1:20000
 #iptables -t mangle -A PREROUTING -p udp -j TPROXY --on-port 20000 --tproxy-mark 0x01/0x01
+iptables -t filter -A FORWARD -s 192.168.200.0/24 -j ACCEPT
+iptables -t filter -A FORWARD -d 192.168.200.0/24 -j ACCEPT
 iptables -t nat -A POSTROUTING --ipv4 -j MASQUERADE
 node $basepath/start.js


### PR DESCRIPTION
测试环境：
PS5 + Ubuntu 20（非 VM）

系统为原生 Ubuntu 20，非 VM，和 PS5 处于同一个局域网。
使用原先的脚本，会出现互联网流量没有被转发的问题，直接效果是 PS5 在配置了 192.168.200.0/24 网段的 IP 后出现无法访问互联网的情况。

我本人对 iptables 并不是很熟悉，结合一些网上的转发配置指导，尝试在 filter 表配置此网段的 FORWARD 链后可以解决这个问题，且可以正常直播，所以贡献一下这个改动。但是我也不确定为什么以前并没有看到有人报过这个具体问题，也不确定是否为 Ubuntu 20 独有的问题。受测试环境所限，这个改动没有经过更多的测试，建议确认改动无害后再合入。

另外，因为 filter 表可能还有别的条目，我没有像 nat 表一样在执行前清空整个表。如果这里还有更好的清理方式，也欢迎对这个 PR 做更多改动。

#46 可能也与此有关，但信息太少无法判断。